### PR TITLE
feat: Add support for contact fields (PHON, EMAIL, FAX, WWW)

### DIFF
--- a/gramps_gedcom7/event.py
+++ b/gramps_gedcom7/event.py
@@ -4,7 +4,7 @@ from gedcom7 import const as g7const
 from gedcom7 import grammar as g7grammar
 from gedcom7 import types as g7types
 from gedcom7 import util as g7util
-from gramps.gen.lib import Event, EventType, Place, PlaceName
+from gramps.gen.lib import Attribute, AttributeType, Event, EventType, Place, PlaceName
 from gramps.gen.lib.primaryobj import BasicPrimaryObject
 
 from . import util
@@ -42,9 +42,33 @@ def handle_event(
                 event.set_type(EventType(child.value))
         elif child.tag == g7const.RESN:
             util.set_privacy_on_object(resn_structure=child, obj=event)
+        elif child.tag == g7const.PHON:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Phone: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.EMAIL:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Email: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.FAX:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Fax: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.WWW:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Website: {child.value}")
+            event.add_attribute(attr)
         # TODO handle association
         # TODO handle address
-        # TODO handle PHON, EMAIL, FAX, WWW, AGNC, RELI, CAUS
+        # TODO handle AGNC, RELI, CAUS
         elif child.tag == g7const.SNOTE and child.pointer != g7grammar.voidptr:
             try:
                 note_handle = xref_handle_map[child.pointer]

--- a/gramps_gedcom7/individual.py
+++ b/gramps_gedcom7/individual.py
@@ -6,12 +6,15 @@ from gedcom7 import const as g7const
 from gedcom7 import grammar as g7grammar
 from gedcom7 import types as g7types
 from gramps.gen.lib import (
+    Address,
     EventRef,
     EventType,
     Name,
     NameType,
     Person,
     Surname,
+    Url,
+    UrlType,
 )
 from gramps.gen.lib.primaryobj import BasicPrimaryObject
 
@@ -94,6 +97,30 @@ def handle_individual(
                 person.set_primary_name(name)
             else:
                 person.add_alternate_name(name)
+        elif child.tag == g7const.PHON:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            # Create address with phone
+            address = Address()
+            address.set_phone(child.value)
+            person.add_address(address)
+        elif child.tag == g7const.EMAIL:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            url = Url()
+            url.set_path(child.value)
+            url.set_type(UrlType(UrlType.EMAIL))
+            person.add_url(url)
+        elif child.tag == g7const.FAX:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            # Store FAX in address (no dedicated FAX field)
+            address = Address()
+            address.set_phone(f"FAX: {child.value}")
+            person.add_address(address)
+        elif child.tag == g7const.WWW:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            url = Url()
+            url.set_path(child.value)
+            url.set_type(UrlType(UrlType.WEB_HOME))
+            person.add_url(url)
         # TODO handle attributes
         # TODO handle SUBM
         # TODO handle associations

--- a/gramps_gedcom7/repository.py
+++ b/gramps_gedcom7/repository.py
@@ -1,7 +1,7 @@
 """Handle GEDCOM repository records and import them into the Gramps database."""
 
 from typing import List
-from gramps.gen.lib import Repository, NoteType, Url, UrlType
+from gramps.gen.lib import Address, Repository, NoteType, Url, UrlType
 from gramps.gen.lib.primaryobj import BasicPrimaryObject
 from gedcom7 import types as g7types, const as g7const, util as g7util
 from . import util
@@ -51,7 +51,18 @@ def handle_repository(
         elif child.tag == g7const.NOTE:
             repository, note = util.add_note_to_object(child, repository)
             objects.append(note)
-        # TODO handle PHON
+        elif child.tag == g7const.PHON:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            # Repository supports addresses with phone
+            address = Address()
+            address.set_phone(child.value)
+            repository.add_address(address)
+        elif child.tag == g7const.FAX:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            # Store FAX in address with prefix
+            address = Address()
+            address.set_phone(f"FAX: {child.value}")
+            repository.add_address(address)
         # TODO handle address
         # TODO handle identifier
     repository = util.add_ids(

--- a/test/data/contact_fields.ged
+++ b/test/data/contact_fields.ged
@@ -1,0 +1,24 @@
+0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @R1@ REPO
+1 NAME Test Repository
+1 PHON +1-555-0123
+1 FAX +1-555-0124
+1 EMAIL repo@example.com
+1 WWW https://example.com
+0 @I1@ INDI
+1 NAME John /Doe/
+1 PHON +1-555-0125
+1 FAX +1-555-0126
+1 EMAIL john@example.com
+1 WWW https://johndoe.com
+0 @I2@ INDI
+1 NAME Jane /Doe/
+1 BIRT
+2 DATE 1 JAN 1970
+2 PHON +1-555-0127
+2 EMAIL birth@hospital.com
+2 FAX +1-555-0128
+2 WWW https://hospital.com/births
+0 TRLR

--- a/test/test_contact_fields.py
+++ b/test/test_contact_fields.py
@@ -1,0 +1,173 @@
+"""Test import of contact fields (PHON, EMAIL, FAX, WWW)."""
+
+from pathlib import Path
+from gramps.gen.db import DbWriteBase
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import AttributeType, EventType, UrlType
+from gramps_gedcom7.importer import import_gedcom
+
+
+def test_contact_fields_repository():
+    """Test import of PHON, FAX, EMAIL, WWW for repositories."""
+    gedcom_file = "test/data/contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get repository
+    repos = list(db.iter_repositories())
+    assert len(repos) == 1
+    repo = repos[0]
+    assert repo.name == "Test Repository"
+    
+    # Check URLs (EMAIL and WWW)
+    urls = repo.get_url_list()
+    email_urls = [u for u in urls if u.get_type() == UrlType.EMAIL]
+    assert len(email_urls) == 1
+    assert email_urls[0].get_path() == "repo@example.com"
+    
+    web_urls = [u for u in urls if u.get_type() == UrlType.WEB_HOME]
+    assert len(web_urls) == 1
+    assert web_urls[0].get_path() == "https://example.com"
+    
+    # Check addresses (PHON and FAX stored in addresses)
+    addresses = repo.get_address_list()
+    assert len(addresses) == 2
+    
+    # Check phone in address
+    phone_addrs = [a for a in addresses if a.get_phone() and "FAX" not in a.get_phone()]
+    assert len(phone_addrs) == 1
+    assert phone_addrs[0].get_phone() == "+1-555-0123"
+    
+    # Check fax in address
+    fax_addrs = [a for a in addresses if a.get_phone() and "FAX" in a.get_phone()]
+    assert len(fax_addrs) == 1
+    assert fax_addrs[0].get_phone() == "FAX: +1-555-0124"
+
+
+def test_contact_fields_individual():
+    """Test import of PHON, FAX, EMAIL, WWW for individuals."""
+    gedcom_file = "test/data/contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get first person (John Doe)
+    persons = list(db.iter_people())
+    john = [p for p in persons if "John" in p.get_primary_name().get_first_name()][0]
+    
+    # Check addresses (PHON and FAX stored in addresses)
+    addresses = john.get_address_list()
+    assert len(addresses) == 2
+    
+    # Check phone in address
+    phone_addrs = [a for a in addresses if a.get_phone() and "FAX" not in a.get_phone()]
+    assert len(phone_addrs) == 1
+    assert phone_addrs[0].get_phone() == "+1-555-0125"
+    
+    # Check fax in address
+    fax_addrs = [a for a in addresses if a.get_phone() and "FAX" in a.get_phone()]
+    assert len(fax_addrs) == 1
+    assert fax_addrs[0].get_phone() == "FAX: +1-555-0126"
+    
+    # Check URLs (EMAIL and WWW)
+    urls = john.get_url_list()
+    assert len(urls) == 2
+    
+    email_urls = [u for u in urls if u.get_type() == UrlType.EMAIL]
+    assert len(email_urls) == 1
+    assert email_urls[0].get_path() == "john@example.com"
+    
+    web_urls = [u for u in urls if u.get_type() == UrlType.WEB_HOME]
+    assert len(web_urls) == 1
+    assert web_urls[0].get_path() == "https://johndoe.com"
+
+
+def test_contact_fields_event():
+    """Test import of contact fields in events."""
+    gedcom_file = "test/data/contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get Jane Doe
+    persons = list(db.iter_people())
+    jane = [p for p in persons if "Jane" in p.get_primary_name().get_first_name()][0]
+    
+    # Get birth event
+    event_refs = jane.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    birth_events = [e for e in events if e.get_type() == EventType.BIRTH]
+    assert len(birth_events) == 1
+    birth = birth_events[0]
+    
+    # Check event attributes for contact fields
+    attrs = birth.get_attribute_list()
+    assert len(attrs) == 4  # PHON, EMAIL, FAX, WWW
+    
+    # Check phone attribute
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0127"
+    
+    # Check email attribute
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: birth@hospital.com"
+    
+    # Check fax attribute
+    fax_attrs = [a for a in attrs if "Fax:" in a.get_value()]
+    assert len(fax_attrs) == 1
+    assert fax_attrs[0].get_value() == "Fax: +1-555-0128"
+    
+    # Check website attribute
+    www_attrs = [a for a in attrs if "Website:" in a.get_value()]
+    assert len(www_attrs) == 1
+    assert www_attrs[0].get_value() == "Website: https://hospital.com/births"
+
+
+def test_multiple_contact_fields():
+    """Test that multiple instances of the same contact field type are preserved."""
+    # Create GEDCOM with multiple phone numbers
+    gedcom_text = """0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME Multi /Contact/
+1 PHON +1-555-0001
+1 PHON +1-555-0002
+1 EMAIL first@example.com
+1 EMAIL second@example.com
+0 TRLR"""
+    
+    # Write test file
+    test_file = Path(__file__).parent / "data" / "multi_contact.ged"
+    test_file.write_text(gedcom_text)
+    
+    gedcom_file = str(test_file)
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get person
+    persons = list(db.iter_people())
+    assert len(persons) == 1
+    person = persons[0]
+    
+    # Check multiple phone numbers in addresses
+    addresses = person.get_address_list()
+    phones = [a.get_phone() for a in addresses if a.get_phone()]
+    assert len(phones) == 2
+    assert "+1-555-0001" in phones
+    assert "+1-555-0002" in phones
+    
+    # Check multiple email addresses in URLs
+    urls = person.get_url_list()
+    email_urls = [u for u in urls if u.get_type() == UrlType.EMAIL]
+    assert len(email_urls) == 2
+    emails = [u.get_path() for u in email_urls]
+    assert "first@example.com" in emails
+    assert "second@example.com" in emails
+    
+    # Clean up test file
+    test_file.unlink()

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -111,15 +111,25 @@ def test_importer_maximal70():
     assert marriage_media1.gramps_id == "O1"
     assert marriage_media2.gramps_id == "O2"
 
-    # event UID
-    assert len(marriage.attribute_list) == 2
-    assert marriage.attribute_list[0].get_type() == "UID"
+    # event UID + contact fields (8 contact fields: 2 PHON, 2 EMAIL, 2 FAX, 2 WWW)
+    assert len(marriage.attribute_list) == 10  # 8 contact fields + 2 UID
+    # Contact fields are added first (indexes 0-7)
+    assert "Phone:" in marriage.attribute_list[0].get_value()
+    assert "Phone:" in marriage.attribute_list[1].get_value()
+    assert "Email:" in marriage.attribute_list[2].get_value()
+    assert "Email:" in marriage.attribute_list[3].get_value()
+    assert "Fax:" in marriage.attribute_list[4].get_value()
+    assert "Fax:" in marriage.attribute_list[5].get_value()
+    assert "Website:" in marriage.attribute_list[6].get_value()
+    assert "Website:" in marriage.attribute_list[7].get_value()
+    # UIDs are at the end (indexes 8-9)
+    assert marriage.attribute_list[8].get_type() == "UID"
     assert (
-        marriage.attribute_list[0].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
+        marriage.attribute_list[8].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
     )
-    assert marriage.attribute_list[1].get_type() == "UID"
+    assert marriage.attribute_list[9].get_type() == "UID"
     assert (
-        marriage.attribute_list[1].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
+        marriage.attribute_list[9].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
     )
 
     # custom event (line 123)
@@ -344,12 +354,13 @@ def test_importer_maximal70():
     assert event_media1.gramps_id == "O1"
     assert event_media2.gramps_id == "O2"
 
-    # person event UID
-    assert len(event.attribute_list) == 2
-    assert event.attribute_list[0].get_type() == "UID"
-    assert event.attribute_list[0].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
-    assert event.attribute_list[1].get_type() == "UID"
-    assert event.attribute_list[1].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
+    # person event UID + contact fields (DEAT event has contact fields too)
+    assert len(event.attribute_list) == 10  # 8 contact fields + 2 UID
+    # Contact fields are first (same as marriage event)
+    assert event.attribute_list[8].get_type() == "UID"
+    assert event.attribute_list[8].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
+    assert event.attribute_list[9].get_type() == "UID"
+    assert event.attribute_list[9].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
 
     # EMIG - Emigration
     event = db.get_event_from_handle(person.event_ref_list[11].ref)


### PR DESCRIPTION
## Summary

Implements support for GEDCOM 7 contact fields (`PHON`, `EMAIL`, `FAX`, `WWW`) across all supported record types.

## Implementation

### Repository Records
- `PHON`/`FAX` → Address objects with phone field
- `EMAIL`/`WWW` → URL objects (EMAIL already existed, added PHON/FAX)

### Individual Records  
- `PHON`/`FAX` → Address objects with phone field
- `EMAIL`/`WWW` → URL objects with appropriate UrlType

### Event Records
- All contact fields → Custom attributes (Events lack URL/address support)

## Changes

**Modified:**
- `gramps_gedcom7/repository.py` - Added PHON/FAX handlers
- `gramps_gedcom7/individual.py` - Added all four contact field handlers
- `gramps_gedcom7/event.py` - Added all four contact field handlers
- `test/test_importer.py` - Updated assertions for new attributes

**Added:**
- `test/data/contact_fields.ged` - Test GEDCOM file
- `test/test_contact_fields.py` - Test coverage for all scenarios

## Testing

```bash
python3 -m pytest test/test_contact_fields.py -v
python3 -m pytest test/test_importer.py::test_importer_maximal70 -v
```

All tests pass.

## Notes

- Supports multiple instances per GEDCOM 7.0 spec (`{0:M}` cardinality)
- Addresses TODO comments in event.py:47 and repository.py:54
- FAX stored with "FAX: " prefix in phone field (Gramps lacks dedicated FAX field)