### PR TITLE
feat: Add support for event contact fields

### DIFF
--- a/gramps_gedcom7/event.py
+++ b/gramps_gedcom7/event.py
@@ -4,7 +4,7 @@ from gedcom7 import const as g7const
 from gedcom7 import grammar as g7grammar
 from gedcom7 import types as g7types
 from gedcom7 import util as g7util
-from gramps.gen.lib import Event, EventType, Place, PlaceName
+from gramps.gen.lib import Attribute, AttributeType, Event, EventType, Place, PlaceName
 from gramps.gen.lib.primaryobj import BasicPrimaryObject
 
 from . import util
@@ -44,7 +44,31 @@ def handle_event(
             util.set_privacy_on_object(resn_structure=child, obj=event)
         # TODO handle association
         # TODO handle address
-        # TODO handle PHON, EMAIL, FAX, WWW, AGNC, RELI, CAUS
+        # TODO handle AGNC, RELI, CAUS
+        elif child.tag == g7const.PHON:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Phone: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.EMAIL:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Email: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.FAX:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Fax: {child.value}")
+            event.add_attribute(attr)
+        elif child.tag == g7const.WWW:
+            assert isinstance(child.value, str), "Expected value to be a string"
+            attr = Attribute()
+            attr.set_type(AttributeType.CUSTOM)
+            attr.set_value(f"Website: {child.value}")
+            event.add_attribute(attr)
         elif child.tag == g7const.SNOTE and child.pointer != g7grammar.voidptr:
             try:
                 note_handle = xref_handle_map[child.pointer]

--- a/test/data/event_contact_fields.ged
+++ b/test/data/event_contact_fields.ged
@@ -1,0 +1,56 @@
+0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME John /Smith/
+1 SEX M
+1 BIRT
+2 DATE 1 JAN 1950
+2 PLAC Birth Hospital
+2 PHON +1-555-0100
+2 EMAIL birth.registry@hospital.org
+2 FAX +1-555-0101
+2 WWW http://hospital.org/birth-records
+1 DEAT
+2 DATE 31 DEC 2020
+2 PLAC City Hospital
+2 PHON +1-555-0200
+2 PHON +1-555-0201
+2 EMAIL coroner@county.gov
+2 EMAIL admin@hospital.org
+2 FAX +1-555-0202
+2 FAX +1-555-0203
+2 WWW http://county.gov/deaths
+2 WWW http://hospital.org/records
+0 @I2@ INDI
+1 NAME Jane /Doe/
+1 SEX F
+1 BAPM
+2 DATE 15 MAR 1955
+2 PLAC First Baptist Church
+2 PHON +1-555-0300
+2 EMAIL church@firstbaptist.org
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+1 MARR
+2 DATE 1 JUN 1975
+2 PLAC City Hall
+2 PHON +1-555-0400
+2 EMAIL clerk@city.gov
+2 FAX +1-555-0401
+2 WWW http://city.gov/marriages
+1 DIV
+2 DATE 1 JAN 2000
+2 PHON +1-555-0500
+2 EMAIL court@district.gov
+0 @I3@ INDI
+1 NAME Test /Person/
+1 EVEN
+2 TYPE Graduation
+2 DATE 15 MAY 2000
+2 PHON +1-555-0600
+2 EMAIL registrar@university.edu
+2 FAX +1-555-0601
+2 WWW http://university.edu/graduation
+0 TRLR

--- a/test/test_event_contact_fields.py
+++ b/test/test_event_contact_fields.py
@@ -1,0 +1,228 @@
+"""Test import of event contact fields (PHON, EMAIL, FAX, WWW)."""
+
+from gramps.gen.db import DbWriteBase
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import EventType
+from gramps_gedcom7.importer import import_gedcom
+
+
+def test_birth_event_contact_fields():
+    """Test import of contact fields on birth events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get John Smith
+    persons = list(db.iter_people())
+    john = [p for p in persons if "John" in p.get_primary_name().get_first_name()][0]
+    
+    # Get birth event
+    event_refs = john.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    birth_events = [e for e in events if e.get_type() == EventType.BIRTH]
+    assert len(birth_events) == 1
+    birth = birth_events[0]
+    
+    # Check attributes
+    attrs = birth.get_attribute_list()
+    assert len(attrs) == 4
+    
+    # Check contact fields stored as attributes
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0100"
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: birth.registry@hospital.org"
+    
+    fax_attrs = [a for a in attrs if "Fax:" in a.get_value()]
+    assert len(fax_attrs) == 1
+    assert fax_attrs[0].get_value() == "Fax: +1-555-0101"
+    
+    www_attrs = [a for a in attrs if "Website:" in a.get_value()]
+    assert len(www_attrs) == 1
+    assert www_attrs[0].get_value() == "Website: http://hospital.org/birth-records"
+
+
+def test_death_event_multiple_contact_fields():
+    """Test import of multiple contact fields on death events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get John Smith
+    persons = list(db.iter_people())
+    john = [p for p in persons if "John" in p.get_primary_name().get_first_name()][0]
+    
+    # Get death event
+    event_refs = john.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    death_events = [e for e in events if e.get_type() == EventType.DEATH]
+    assert len(death_events) == 1
+    death = death_events[0]
+    
+    # Check attributes (2 PHON, 2 EMAIL, 2 FAX, 2 WWW = 8 total)
+    attrs = death.get_attribute_list()
+    assert len(attrs) == 8
+    
+    # Check multiple instances preserved
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 2
+    phone_values = [a.get_value() for a in phone_attrs]
+    assert "Phone: +1-555-0200" in phone_values
+    assert "Phone: +1-555-0201" in phone_values
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 2
+    email_values = [a.get_value() for a in email_attrs]
+    assert "Email: coroner@county.gov" in email_values
+    assert "Email: admin@hospital.org" in email_values
+    
+    fax_attrs = [a for a in attrs if "Fax:" in a.get_value()]
+    assert len(fax_attrs) == 2
+    
+    www_attrs = [a for a in attrs if "Website:" in a.get_value()]
+    assert len(www_attrs) == 2
+
+
+def test_baptism_event_contact_fields():
+    """Test import of contact fields on baptism events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get Jane Doe
+    persons = list(db.iter_people())
+    jane = [p for p in persons if "Jane" in p.get_primary_name().get_first_name()][0]
+    
+    # Get baptism event
+    event_refs = jane.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    baptism_events = [e for e in events if e.get_type() == EventType.BAPTISM]
+    assert len(baptism_events) == 1
+    baptism = baptism_events[0]
+    
+    # Check attributes
+    attrs = baptism.get_attribute_list()
+    assert len(attrs) == 2  # Only PHON and EMAIL
+    
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0300"
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: church@firstbaptist.org"
+
+
+def test_marriage_event_contact_fields():
+    """Test import of contact fields on family events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get family
+    families = list(db.iter_families())
+    family = families[0]
+    
+    # Get marriage event
+    event_refs = family.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    marriage_events = [e for e in events if e.get_type() == EventType.MARRIAGE]
+    assert len(marriage_events) == 1
+    marriage = marriage_events[0]
+    
+    # Check attributes
+    attrs = marriage.get_attribute_list()
+    assert len(attrs) == 4
+    
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0400"
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: clerk@city.gov"
+    
+    fax_attrs = [a for a in attrs if "Fax:" in a.get_value()]
+    assert len(fax_attrs) == 1
+    assert fax_attrs[0].get_value() == "Fax: +1-555-0401"
+    
+    www_attrs = [a for a in attrs if "Website:" in a.get_value()]
+    assert len(www_attrs) == 1
+    assert www_attrs[0].get_value() == "Website: http://city.gov/marriages"
+
+
+def test_divorce_event_contact_fields():
+    """Test import of partial contact fields on divorce events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get family
+    families = list(db.iter_families())
+    family = families[0]
+    
+    # Get divorce event
+    event_refs = family.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    divorce_events = [e for e in events if e.get_type() == EventType.DIVORCE]
+    assert len(divorce_events) == 1
+    divorce = divorce_events[0]
+    
+    # Check attributes (only PHON and EMAIL, no FAX or WWW)
+    attrs = divorce.get_attribute_list()
+    assert len(attrs) == 2
+    
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0500"
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: court@district.gov"
+
+
+def test_custom_event_contact_fields():
+    """Test import of contact fields on custom events."""
+    gedcom_file = "test/data/event_contact_fields.ged"
+    db: DbWriteBase = make_database("sqlite")
+    db.load(":memory:", callback=None)
+    import_gedcom(gedcom_file, db)
+    
+    # Get Test Person
+    persons = list(db.iter_people())
+    test_person = [p for p in persons if "Test" in p.get_primary_name().get_first_name()][0]
+    
+    # Get custom event
+    event_refs = test_person.get_event_ref_list()
+    events = [db.get_event_from_handle(ref.ref) for ref in event_refs]
+    graduation_events = [e for e in events if e.get_type().string == "Graduation"]
+    assert len(graduation_events) == 1
+    graduation = graduation_events[0]
+    
+    # Check all four contact fields
+    attrs = graduation.get_attribute_list()
+    assert len(attrs) == 4
+    
+    phone_attrs = [a for a in attrs if "Phone:" in a.get_value()]
+    assert len(phone_attrs) == 1
+    assert phone_attrs[0].get_value() == "Phone: +1-555-0600"
+    
+    email_attrs = [a for a in attrs if "Email:" in a.get_value()]
+    assert len(email_attrs) == 1
+    assert email_attrs[0].get_value() == "Email: registrar@university.edu"
+    
+    fax_attrs = [a for a in attrs if "Fax:" in a.get_value()]
+    assert len(fax_attrs) == 1
+    assert fax_attrs[0].get_value() == "Fax: +1-555-0601"
+    
+    www_attrs = [a for a in attrs if "Website:" in a.get_value()]
+    assert len(www_attrs) == 1
+    assert www_attrs[0].get_value() == "Website: http://university.edu/graduation"

--- a/test/test_importer.py
+++ b/test/test_importer.py
@@ -111,16 +111,19 @@ def test_importer_maximal70():
     assert marriage_media1.gramps_id == "O1"
     assert marriage_media2.gramps_id == "O2"
 
-    # event UID
-    assert len(marriage.attribute_list) == 2
-    assert marriage.attribute_list[0].get_type() == "UID"
-    assert (
-        marriage.attribute_list[0].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
-    )
-    assert marriage.attribute_list[1].get_type() == "UID"
-    assert (
-        marriage.attribute_list[1].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
-    )
+    # event attributes (contact fields + UID)
+    assert len(marriage.attribute_list) == 10  # 8 contact fields + 2 UID
+    # Check contact fields (2 PHON, 2 EMAIL, 2 FAX, 2 WWW)
+    contact_attrs = [a for a in marriage.attribute_list if any(
+        prefix in a.get_value() for prefix in ["Phone:", "Email:", "Fax:", "Website:"]
+    )]
+    assert len(contact_attrs) == 8
+    # Check UID attributes
+    uid_attrs = [a for a in marriage.attribute_list if a.get_type() == "UID"]
+    assert len(uid_attrs) == 2
+    uid_values = [a.get_value() for a in uid_attrs]
+    assert "bbcc0025-34cb-4542-8cfb-45ba201c9c2c" in uid_values
+    assert "9ead4205-5bad-4c05-91c1-0aecd3f5127d" in uid_values
 
     # custom event (line 123)
     event = db.get_event_from_handle(family.event_ref_list[10].ref)
@@ -344,12 +347,19 @@ def test_importer_maximal70():
     assert event_media1.gramps_id == "O1"
     assert event_media2.gramps_id == "O2"
 
-    # person event UID
-    assert len(event.attribute_list) == 2
-    assert event.attribute_list[0].get_type() == "UID"
-    assert event.attribute_list[0].get_value() == "bbcc0025-34cb-4542-8cfb-45ba201c9c2c"
-    assert event.attribute_list[1].get_type() == "UID"
-    assert event.attribute_list[1].get_value() == "9ead4205-5bad-4c05-91c1-0aecd3f5127d"
+    # person event attributes (contact fields + UID)
+    assert len(event.attribute_list) == 10  # 8 contact fields + 2 UID
+    # Check contact fields
+    contact_attrs = [a for a in event.attribute_list if any(
+        prefix in a.get_value() for prefix in ["Phone:", "Email:", "Fax:", "Website:"]
+    )]
+    assert len(contact_attrs) == 8
+    # Check UID attributes
+    uid_attrs = [a for a in event.attribute_list if a.get_type() == "UID"]
+    assert len(uid_attrs) == 2
+    uid_values = [a.get_value() for a in uid_attrs]
+    assert "bbcc0025-34cb-4542-8cfb-45ba201c9c2c" in uid_values
+    assert "9ead4205-5bad-4c05-91c1-0aecd3f5127d" in uid_values
 
     # EMIG - Emigration
     event = db.get_event_from_handle(person.event_ref_list[11].ref)


### PR DESCRIPTION
This PR implements support for GEDCOM 7 contact fields (PHON, EMAIL, FAX, WWW) in events.

## Changes
- Added handlers in `event.py` for PHON, EMAIL, FAX, WWW tags
- Contact information is stored as Gramps attributes with descriptive prefixes
- Supports multiple instances of each contact field type

## Testing
- Created comprehensive test file with 6 test cases
- Tests cover various event types (birth, death, baptism, marriage, divorce, custom)
- Tests verify single and multiple contact field instances
- Updated existing tests in test_importer.py to account for new attributes

This closes the TODO in event.py:47 regarding contact fields.