### PR TITLE
Fail with a clear error on non-UTF-8 GEDCOM files

### DIFF
--- a/gramps_gedcom7/importer.py
+++ b/gramps_gedcom7/importer.py
@@ -25,12 +25,22 @@ def import_gedcom(
     """
     # Check if input_file is a string or Path object
     if isinstance(input_file, (str, Path)):
-        with open(input_file, "r", encoding="utf-8") as f:
-            gedcom_data: str = f.read()
+        try:
+            with open(input_file, "r", encoding="utf-8") as f:
+                gedcom_data: str = f.read()
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"GEDCOM 7 requires UTF-8 encoding, but '{input_file}' contains invalid UTF-8 bytes: {e}"
+            ) from e
     elif isinstance(input_file, TextIO):
         gedcom_data = input_file.read()
     elif isinstance(input_file, BinaryIO):
-        gedcom_data = input_file.read().decode("utf-8")
+        try:
+            gedcom_data = input_file.read().decode("utf-8")
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"GEDCOM 7 requires UTF-8 encoding, but the file contains invalid UTF-8 bytes: {e}"
+            ) from e
     else:
         raise TypeError(
             "input_file must be a string, Path object, or file-like object."

--- a/gramps_gedcom7/importer.py
+++ b/gramps_gedcom7/importer.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from gramps.gen.db import DbWriteBase
 import gedcom7
+import io
 from pathlib import Path
 from typing import TextIO, BinaryIO
 
@@ -32,14 +33,14 @@ def import_gedcom(
             raise ValueError(
                 f"GEDCOM 7 requires UTF-8 encoding, but '{input_file}' contains invalid UTF-8 bytes: {e}"
             ) from e
-    elif isinstance(input_file, TextIO):
+    elif isinstance(input_file, io.TextIOBase):
         try:
             gedcom_data = input_file.read()
         except UnicodeDecodeError as e:
             raise ValueError(
                 f"GEDCOM 7 requires UTF-8 encoding, but the file contains invalid UTF-8 bytes: {e}"
             ) from e
-    elif isinstance(input_file, BinaryIO):
+    elif isinstance(input_file, (io.RawIOBase, io.BufferedIOBase)):
         try:
             gedcom_data = input_file.read().decode("utf-8")
         except UnicodeDecodeError as e:

--- a/gramps_gedcom7/importer.py
+++ b/gramps_gedcom7/importer.py
@@ -33,7 +33,12 @@ def import_gedcom(
                 f"GEDCOM 7 requires UTF-8 encoding, but '{input_file}' contains invalid UTF-8 bytes: {e}"
             ) from e
     elif isinstance(input_file, TextIO):
-        gedcom_data = input_file.read()
+        try:
+            gedcom_data = input_file.read()
+        except UnicodeDecodeError as e:
+            raise ValueError(
+                f"GEDCOM 7 requires UTF-8 encoding, but the file contains invalid UTF-8 bytes: {e}"
+            ) from e
     elif isinstance(input_file, BinaryIO):
         try:
             gedcom_data = input_file.read().decode("utf-8")

--- a/gramps_gedcom7/streamlit_app.py
+++ b/gramps_gedcom7/streamlit_app.py
@@ -141,16 +141,12 @@ def convert_gedcom_to_xml(
         finally:
             Path(input_temp_path).unlink(missing_ok=True)
 
-    except ValueError as e:
-        if isinstance(e.__cause__, UnicodeDecodeError):
-            errors.append(str(e))
-            return None, errors, warnings
-        raise
     except Exception as e:
-        error_msg = f"Conversion error: {str(e)}"
-        errors.append(error_msg)
-        full_error = traceback.format_exc()
-        errors.append(f"Full error:\n{full_error}")
+        if isinstance(e, ValueError) and isinstance(e.__cause__, UnicodeDecodeError):
+            errors.append(str(e))
+        else:
+            errors.append(f"Conversion error: {str(e)}")
+            errors.append(f"Full error:\n{traceback.format_exc()}")
         return None, errors, warnings
 
 

--- a/gramps_gedcom7/streamlit_app.py
+++ b/gramps_gedcom7/streamlit_app.py
@@ -141,6 +141,9 @@ def convert_gedcom_to_xml(
         finally:
             Path(input_temp_path).unlink(missing_ok=True)
 
+    except ValueError as e:
+        errors.append(str(e))
+        return None, errors, warnings
     except Exception as e:
         error_msg = f"Conversion error: {str(e)}"
         errors.append(error_msg)

--- a/gramps_gedcom7/streamlit_app.py
+++ b/gramps_gedcom7/streamlit_app.py
@@ -94,11 +94,13 @@ def convert_gedcom_to_xml(
             if isinstance(gedcom_content, bytes):
                 try:
                     gedcom_content = gedcom_content.decode("utf-8")
-                except UnicodeDecodeError:
-                    try:
-                        gedcom_content = gedcom_content.decode("latin-1")
-                    except UnicodeDecodeError:
-                        gedcom_content = gedcom_content.decode("cp1252")
+                except UnicodeDecodeError as e:
+                    raise ValueError(
+                        f"The uploaded file is not valid UTF-8. GEDCOM 7 requires UTF-8 encoding. "
+                        f"If this file was exported by older software it may use a legacy encoding "
+                        f"(e.g. ANSEL, latin-1, or Windows-1252) and must be converted before import. "
+                        f"Detail: {e}"
+                    ) from e
             input_temp.write(gedcom_content)
             input_temp_path = input_temp.name
 

--- a/gramps_gedcom7/streamlit_app.py
+++ b/gramps_gedcom7/streamlit_app.py
@@ -142,8 +142,10 @@ def convert_gedcom_to_xml(
             Path(input_temp_path).unlink(missing_ok=True)
 
     except ValueError as e:
-        errors.append(str(e))
-        return None, errors, warnings
+        if isinstance(e.__cause__, UnicodeDecodeError):
+            errors.append(str(e))
+            return None, errors, warnings
+        raise
     except Exception as e:
         error_msg = f"Conversion error: {str(e)}"
         errors.append(error_msg)


### PR DESCRIPTION
GEDCOM 7 mandates UTF-8. The API now raises ValueError with an explanatory message instead of an opaque UnicodeDecodeError. The Streamlit app replaces its silent latin-1/cp1252 fallback with the same error, surfaced to the user via the existing error panel.